### PR TITLE
Add simplified cocktail order dialog

### DIFF
--- a/frontend/src/components/CSimpleOrderDialog.vue
+++ b/frontend/src/components/CSimpleOrderDialog.vue
@@ -1,0 +1,111 @@
+<template>
+  <q-dialog
+    :model-value="show"
+    persistent
+    @update:model-value="$emit('update:show', $event)"
+    maximized
+  >
+    <q-card class="text-center bg-background text-background">
+      <q-card-section>
+        <div class="text-weight-medium">{{ $t('component.simple_order_dialog.headline') }}</div>
+        <div class="text-subtitle2">{{ recipe.name }}</div>
+      </q-card-section>
+      <q-separator :dark="color.backgroundDark" />
+      <q-card-section>
+        <div class="row q-gutter-md justify-center">
+          <q-btn
+            no-caps
+            :color="selected === 'default' ? 'positive' : 'secondary'"
+            @click="select('default')"
+          >
+            {{ $t('component.simple_order_dialog.default_label', { nr: recommendedAmount }) }}
+          </q-btn>
+          <q-btn
+            no-caps
+            :color="selected === 'checker' ? 'positive' : 'secondary'"
+            @click="select('checker')"
+          >
+            {{ $t('component.simple_order_dialog.checker_label', { nr: checkerAmount }) }}
+          </q-btn>
+        </div>
+      </q-card-section>
+      <q-card-actions align="center">
+        <q-btn
+          color="positive"
+          no-caps
+          :disable="!selected || ordering"
+          :loading="ordering"
+          @click="onMakeCocktail"
+        >
+          {{ $t('component.simple_order_dialog.make_btn_label') }}
+        </q-btn>
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import GlassService from '../services/glass.service'
+import CocktailService from '../services/cocktail.service'
+
+export default {
+  name: 'CSimpleOrderDialog',
+  props: {
+    show: { type: Boolean, default: false },
+    recipe: { type: Object, required: true }
+  },
+  emits: ['update:show', 'postOrder'],
+  data () {
+    return {
+      availableGlasses: [],
+      selected: null,
+      ordering: false
+    }
+  },
+  created () {
+    GlassService.getAllGlasses().then(g => {
+      this.availableGlasses = g
+    })
+  },
+  computed: {
+    ...mapGetters({
+      color: 'appearance/getNormalColors'
+    }),
+    recommendedAmount () {
+      return this.recipe?.defaultGlass?.size || 250
+    },
+    checkerAmount () {
+      if (this.availableGlasses.length === 0) {
+        return this.recommendedAmount * 2
+      }
+      return Math.max(...this.availableGlasses.map(x => x.size))
+    }
+  },
+  methods: {
+    select (val) {
+      this.selected = val
+    },
+    onMakeCocktail () {
+      const amount = this.selected === 'checker' ? this.checkerAmount : this.recommendedAmount
+      const config = {
+        amountOrderedInMl: amount,
+        customisations: { boost: 100, additionalIngredients: [] },
+        ingredientGroupReplacements: []
+      }
+      this.ordering = true
+      CocktailService.order(this.recipe.id, config, this.recipe.type === 'ingredientrecipe')
+        .then(() => {
+          this.$emit('postOrder')
+        })
+        .finally(() => {
+          this.ordering = false
+        })
+    }
+  }
+}
+</script>
+
+<style scoped>
+</style>
+

--- a/frontend/src/components/CSimpleRecipeList.vue
+++ b/frontend/src/components/CSimpleRecipeList.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <c-make-cocktail-dialog
+    <c-simple-order-dialog
       :recipe="orderDialog.recipe"
       v-if="!!orderDialog.recipe"
       v-model:show="orderDialog.show"
@@ -31,11 +31,11 @@
 
 <script>
 import CSimpleRecipeCard from 'components/CSimpleRecipeCard'
-import CMakeCocktailDialog from 'components/CMakeCocktailDialog'
+import CSimpleOrderDialog from 'components/CSimpleOrderDialog'
 import RecipeService from 'src/services/recipe.service'
 export default {
   name: 'CSimpleRecipeList',
-  components: { CMakeCocktailDialog, CSimpleRecipeCard },
+  components: { CSimpleOrderDialog, CSimpleRecipeCard },
   props: {
     isIngredientRecipe: {
       type: Boolean,

--- a/frontend/src/i18n/da_DK/index.js
+++ b/frontend/src/i18n/da_DK/index.js
@@ -604,6 +604,12 @@ export default {
       headline: 'Bestil Cocktail',
       order_btn_label: 'LAV COCKTAIL ({nr} ml)'
     },
+    simple_order_dialog: {
+      headline: 'Vælg størrelse',
+      default_label: 'Anbefalet ({nr} ml)',
+      checker_label: 'Checker ({nr} ml)',
+      make_btn_label: 'LAV COCKTAIL'
+    },
     make_cocktail_amount_to_produce: {
       glass_selector_label: 'Glas',
       amount_to_produce_label: 'Mængde der skal produceres'

--- a/frontend/src/i18n/de/index.js
+++ b/frontend/src/i18n/de/index.js
@@ -651,6 +651,12 @@ export default {
       headline: 'Cocktail bestellen',
       order_btn_label: 'COCKTAIL HERSTELLEN ({nr} ml)'
     },
+    simple_order_dialog: {
+      headline: 'Gr\u00f6\u00dfe w\u00e4hlen',
+      default_label: 'Empfohlen ({nr} ml)',
+      checker_label: 'Checker ({nr} ml)',
+      make_btn_label: 'COCKTAIL HERSTELLEN'
+    },
     make_cocktail_amount_to_produce: {
       glass_selector_label: 'Glas',
       amount_to_produce_label: 'Zu produzierende Menge'

--- a/frontend/src/i18n/en_US/index.js
+++ b/frontend/src/i18n/en_US/index.js
@@ -708,6 +708,12 @@ export default {
       headline: 'Order Cocktail',
       order_btn_label: 'MAKE COCKTAIL ({nr} ml)'
     },
+    simple_order_dialog: {
+      headline: 'Select size',
+      default_label: 'Recommended ({nr} ml)',
+      checker_label: 'Checker ({nr} ml)',
+      make_btn_label: 'MAKE COCKTAIL'
+    },
     make_cocktail_amount_to_produce: {
       glass_selector_label: 'Glass',
       amount_to_produce_label: 'Amount to produce'


### PR DESCRIPTION
## Summary
- add a simple order dialog for fast ordering
- switch simple recipe list to use the new dialog
- add i18n strings for the dialog in `en`, `de`, and `da_DK`

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68564f55bacc833098d2fd53c5304c47