### PR TITLE
Introduce SQLite data layer in Node backend

### DIFF
--- a/backend-ts/package.json
+++ b/backend-ts/package.json
@@ -14,7 +14,8 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.6"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/backend-ts/src/database/database.ts
+++ b/backend-ts/src/database/database.ts
@@ -1,0 +1,45 @@
+import sqlite3 from 'sqlite3';
+import path from 'path';
+import { promisify } from 'util';
+
+export class DB {
+  private db: sqlite3.Database;
+  run: (sql: string, params?: any[]) => Promise<sqlite3.RunResult>;
+  get: (sql: string, params?: any[]) => Promise<any>;
+  all: (sql: string, params?: any[]) => Promise<any[]>;
+
+  constructor(filename: string) {
+    sqlite3.verbose();
+    this.db = new sqlite3.Database(filename);
+    this.run = promisify(this.db.run.bind(this.db));
+    this.get = promisify(this.db.get.bind(this.db));
+    this.all = promisify(this.db.all.bind(this.db));
+  }
+}
+
+let db: DB | undefined;
+
+export function initDatabase(file?: string): DB {
+  if (!db) {
+    const dbFile = file || path.resolve(__dirname, '../../../cocktailpi-data.db');
+    db = new DB(dbFile);
+  }
+  return db;
+}
+
+export function getDatabase(): DB {
+  if (!db) {
+    throw new Error('Database not initialized');
+  }
+  return db;
+}
+
+export async function setupSchema() {
+  const database = getDatabase();
+  await database.run(
+    `CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT NOT NULL UNIQUE, password TEXT NOT NULL, role TEXT NOT NULL)`
+  );
+  await database.run(
+    `CREATE TABLE IF NOT EXISTS recipes (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, description TEXT)`
+  );
+}

--- a/backend-ts/src/index.ts
+++ b/backend-ts/src/index.ts
@@ -3,9 +3,13 @@ import bodyParser from 'body-parser';
 import authRoutes from './routes/auth';
 import recipeRoutes from './routes/recipe';
 import userRoutes from './routes/user';
+import { initDatabase, setupSchema } from './database/database';
 
 const app = express();
 app.use(bodyParser.json());
+
+initDatabase(process.env.DB_PATH);
+setupSchema();
 
 app.use('/api/auth', authRoutes);
 app.use('/api/recipe', recipeRoutes);

--- a/backend-ts/src/routes/auth.ts
+++ b/backend-ts/src/routes/auth.ts
@@ -1,12 +1,12 @@
 import { Router } from 'express';
-import { users } from '../controllers/data';
+import { findUserByUsername } from '../services/userService';
 
 const router = Router();
 
-router.post('/login', (req, res) => {
+router.post('/login', async (req, res) => {
   const { username, password } = req.body;
-  const user = users.find(u => u.username === username && u.password === password);
-  if (!user) {
+  const user = await findUserByUsername(username);
+  if (!user || user.password !== password) {
     return res.status(401).json({ message: 'Invalid credentials' });
   }
   // return dummy token

--- a/backend-ts/src/routes/recipe.ts
+++ b/backend-ts/src/routes/recipe.ts
@@ -1,42 +1,43 @@
 import { Router } from 'express';
-import { recipes } from '../controllers/data';
 import { Recipe } from '../models/recipe';
+import {
+  getAllRecipes,
+  createRecipe,
+  findRecipeById,
+  updateRecipe,
+  deleteRecipe
+} from '../services/recipeService';
 
 const router = Router();
 
-router.get('/', (_req, res) => {
-  res.json(recipes);
+router.get('/', async (_req, res) => {
+  const list = await getAllRecipes();
+  res.json(list);
 });
 
-router.post('/', (req, res) => {
-  const recipe: Recipe = { id: Date.now(), ...req.body };
-  recipes.push(recipe);
+router.post('/', async (req, res) => {
+  const recipe: Recipe = await createRecipe(req.body);
   res.status(201).json(recipe);
 });
 
-router.get('/:id', (req, res) => {
-  const recipe = recipes.find(r => r.id === Number(req.params.id));
+router.get('/:id', async (req, res) => {
+  const recipe = await findRecipeById(Number(req.params.id));
   if (!recipe) {
     return res.status(404).end();
   }
   res.json(recipe);
 });
 
-router.put('/:id', (req, res) => {
-  const idx = recipes.findIndex(r => r.id === Number(req.params.id));
-  if (idx === -1) {
+router.put('/:id', async (req, res) => {
+  const recipe = await updateRecipe(Number(req.params.id), req.body);
+  if (!recipe) {
     return res.status(404).end();
   }
-  recipes[idx] = { ...recipes[idx], ...req.body };
-  res.json(recipes[idx]);
+  res.json(recipe);
 });
 
-router.delete('/:id', (req, res) => {
-  const idx = recipes.findIndex(r => r.id === Number(req.params.id));
-  if (idx === -1) {
-    return res.status(404).end();
-  }
-  recipes.splice(idx, 1);
+router.delete('/:id', async (req, res) => {
+  await deleteRecipe(Number(req.params.id));
   res.status(204).end();
 });
 

--- a/backend-ts/src/routes/user.ts
+++ b/backend-ts/src/routes/user.ts
@@ -1,36 +1,39 @@
 import { Router } from 'express';
-import { users } from '../controllers/data';
 import { User } from '../models/user';
+import {
+  getAllUsers,
+  createUser,
+  findUserById,
+  updateUser,
+  deleteUser
+} from '../services/userService';
 
 const router = Router();
 
-router.get('/', (_req, res) => {
+router.get('/', async (_req, res) => {
+  const users = await getAllUsers();
   res.json(users.map(u => ({ id: u.id, username: u.username, role: u.role })));
 });
 
-router.post('/', (req, res) => {
-  const user: User = { id: Date.now(), ...req.body };
-  users.push(user);
-  res.status(201).json({ id: user.id, username: user.username, role: user.role });
+router.post('/', async (req, res) => {
+  const newUser: User = await createUser(req.body);
+  res.status(201).json({ id: newUser.id, username: newUser.username, role: newUser.role });
 });
 
-router.get('/:id', (req, res) => {
-  const user = users.find(u => u.id === Number(req.params.id));
+router.get('/:id', async (req, res) => {
+  const user = await findUserById(Number(req.params.id));
   if (!user) return res.status(404).end();
   res.json({ id: user.id, username: user.username, role: user.role });
 });
 
-router.put('/:id', (req, res) => {
-  const idx = users.findIndex(u => u.id === Number(req.params.id));
-  if (idx === -1) return res.status(404).end();
-  users[idx] = { ...users[idx], ...req.body };
-  res.json({ id: users[idx].id, username: users[idx].username, role: users[idx].role });
+router.put('/:id', async (req, res) => {
+  const user = await updateUser(Number(req.params.id), req.body);
+  if (!user) return res.status(404).end();
+  res.json({ id: user.id, username: user.username, role: user.role });
 });
 
-router.delete('/:id', (req, res) => {
-  const idx = users.findIndex(u => u.id === Number(req.params.id));
-  if (idx === -1) return res.status(404).end();
-  users.splice(idx, 1);
+router.delete('/:id', async (req, res) => {
+  await deleteUser(Number(req.params.id));
   res.status(204).end();
 });
 

--- a/backend-ts/src/services/recipeService.ts
+++ b/backend-ts/src/services/recipeService.ts
@@ -1,0 +1,30 @@
+import { getDatabase } from '../database/database';
+import { Recipe } from '../models/recipe';
+
+export async function getAllRecipes(): Promise<Recipe[]> {
+  const db = getDatabase();
+  return db.all('SELECT id, name, description FROM recipes');
+}
+
+export async function createRecipe(recipe: Omit<Recipe, "id">): Promise<Recipe> {
+  const db = getDatabase();
+  const result = await db.run('INSERT INTO recipes (name, description) VALUES (?, ?)', [recipe.name, recipe.description]);
+  const id = (result as any).lastID as number;
+  return { id, ...recipe };
+}
+
+export async function findRecipeById(id: number): Promise<Recipe | undefined> {
+  const db = getDatabase();
+  return db.get('SELECT id, name, description FROM recipes WHERE id = ?', [id]);
+}
+
+export async function updateRecipe(id: number, update: Partial<Recipe>): Promise<Recipe | undefined> {
+  const db = getDatabase();
+  await db.run('UPDATE recipes SET name = COALESCE(?, name), description = COALESCE(?, description) WHERE id = ?', [update.name, update.description, id]);
+  return findRecipeById(id);
+}
+
+export async function deleteRecipe(id: number): Promise<void> {
+  const db = getDatabase();
+  await db.run('DELETE FROM recipes WHERE id = ?', [id]);
+}

--- a/backend-ts/src/services/userService.ts
+++ b/backend-ts/src/services/userService.ts
@@ -1,0 +1,35 @@
+import { getDatabase } from '../database/database';
+import { User } from '../models/user';
+
+export async function getAllUsers(): Promise<User[]> {
+  const db = getDatabase();
+  return db.all('SELECT id, username, password, role FROM users');
+}
+
+export async function createUser(user: Omit<User, "id">): Promise<User> {
+  const db = getDatabase();
+  const result = await db.run('INSERT INTO users (username, password, role) VALUES (?, ?, ?)', [user.username, user.password, user.role]);
+  const id = (result as any).lastID as number;
+  return { id, ...user };
+}
+
+export async function findUserById(id: number): Promise<User | undefined> {
+  const db = getDatabase();
+  return db.get('SELECT id, username, password, role FROM users WHERE id = ?', [id]);
+}
+
+export async function findUserByUsername(username: string): Promise<User | undefined> {
+  const db = getDatabase();
+  return db.get('SELECT id, username, password, role FROM users WHERE username = ?', [username]);
+}
+
+export async function updateUser(id: number, update: Partial<User>): Promise<User | undefined> {
+  const db = getDatabase();
+  await db.run('UPDATE users SET username = COALESCE(?, username), password = COALESCE(?, password), role = COALESCE(?, role) WHERE id = ?', [update.username, update.password, update.role, id]);
+  return findUserById(id);
+}
+
+export async function deleteUser(id: number): Promise<void> {
+  const db = getDatabase();
+  await db.run('DELETE FROM users WHERE id = ?', [id]);
+}

--- a/backend-ts/tests/auth.test.ts
+++ b/backend-ts/tests/auth.test.ts
@@ -2,10 +2,18 @@ import request from 'supertest';
 import express from 'express';
 import bodyParser from 'body-parser';
 import authRoutes from '../src/routes/auth';
+import { initDatabase, setupSchema } from '../src/database/database';
+import { createUser } from '../src/services/userService';
 
 const app = express();
 app.use(bodyParser.json());
 app.use('/api/auth', authRoutes);
+
+beforeAll(async () => {
+  initDatabase(':memory:');
+  await setupSchema();
+  await createUser({ username: 'admin', password: 'admin', role: 'ADMIN' });
+});
 
 describe('Auth routes', () => {
   it('should login with default user', async () => {


### PR DESCRIPTION
## Summary
- set up SQLite dependency for the TypeScript backend
- add database helper and service layer for users and recipes
- connect API routes to SQLite
- initialize DB on startup
- adapt tests to use an in-memory DB

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fd65dfff08330ac0838bf560ccc75