### PR TITLE
Add category CRUD endpoints

### DIFF
--- a/backend-ts/README.md
+++ b/backend-ts/README.md
@@ -31,6 +31,16 @@ Run the Jest test suite using:
 npm test
 ```
 
+### API endpoints
+
+Currently implemented routes:
+
+- `POST /api/auth/login` – authenticate a user (dummy token)
+- CRUD operations for recipes under `/api/recipe`
+- CRUD operations for users under `/api/user`
+- CRUD operations for ingredients under `/api/ingredient`
+- CRUD operations for categories under `/api/category`
+
 ## Migration Notice
 
 The TypeScript backend currently coexists with the original Java backend. The goal is to reach feature parity and eventually remove the Java implementation once migration is complete.

--- a/backend-ts/src/database/database.ts
+++ b/backend-ts/src/database/database.ts
@@ -42,4 +42,10 @@ export async function setupSchema() {
   await database.run(
     `CREATE TABLE IF NOT EXISTS recipes (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, description TEXT)`
   );
+  await database.run(
+    `CREATE TABLE IF NOT EXISTS ingredients (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`
+  );
+  await database.run(
+    `CREATE TABLE IF NOT EXISTS categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`
+  );
 }

--- a/backend-ts/src/index.ts
+++ b/backend-ts/src/index.ts
@@ -3,6 +3,8 @@ import bodyParser from 'body-parser';
 import authRoutes from './routes/auth';
 import recipeRoutes from './routes/recipe';
 import userRoutes from './routes/user';
+import ingredientRoutes from './routes/ingredient';
+import categoryRoutes from './routes/category';
 import { initDatabase, setupSchema } from './database/database';
 
 const app = express();
@@ -14,6 +16,8 @@ setupSchema();
 app.use('/api/auth', authRoutes);
 app.use('/api/recipe', recipeRoutes);
 app.use('/api/user', userRoutes);
+app.use('/api/ingredient', ingredientRoutes);
+app.use('/api/category', categoryRoutes);
 
 const port = process.env.PORT || 3000;
 app.listen(port, () => {

--- a/backend-ts/src/models/category.ts
+++ b/backend-ts/src/models/category.ts
@@ -1,0 +1,4 @@
+export interface Category {
+  id: number;
+  name: string;
+}

--- a/backend-ts/src/routes/category.ts
+++ b/backend-ts/src/routes/category.ts
@@ -1,0 +1,44 @@
+import { Router } from 'express';
+import { Category } from '../models/category';
+import {
+  getAllCategories,
+  createCategory,
+  findCategoryById,
+  updateCategory,
+  deleteCategory,
+} from '../services/categoryService';
+
+const router = Router();
+
+router.get('/', async (_req, res) => {
+  const list = await getAllCategories();
+  res.json(list);
+});
+
+router.post('/', async (req, res) => {
+  const category: Category = await createCategory(req.body);
+  res.status(201).json(category);
+});
+
+router.get('/:id', async (req, res) => {
+  const category = await findCategoryById(Number(req.params.id));
+  if (!category) {
+    return res.status(404).end();
+  }
+  res.json(category);
+});
+
+router.put('/:id', async (req, res) => {
+  const category = await updateCategory(Number(req.params.id), req.body);
+  if (!category) {
+    return res.status(404).end();
+  }
+  res.json(category);
+});
+
+router.delete('/:id', async (req, res) => {
+  await deleteCategory(Number(req.params.id));
+  res.status(204).end();
+});
+
+export default router;

--- a/backend-ts/src/routes/ingredient.ts
+++ b/backend-ts/src/routes/ingredient.ts
@@ -1,0 +1,44 @@
+import { Router } from 'express';
+import { Ingredient } from '../models/ingredient';
+import {
+  getAllIngredients,
+  createIngredient,
+  findIngredientById,
+  updateIngredient,
+  deleteIngredient,
+} from '../services/ingredientService';
+
+const router = Router();
+
+router.get('/', async (_req, res) => {
+  const list = await getAllIngredients();
+  res.json(list);
+});
+
+router.post('/', async (req, res) => {
+  const ingredient: Ingredient = await createIngredient(req.body);
+  res.status(201).json(ingredient);
+});
+
+router.get('/:id', async (req, res) => {
+  const ingredient = await findIngredientById(Number(req.params.id));
+  if (!ingredient) {
+    return res.status(404).end();
+  }
+  res.json(ingredient);
+});
+
+router.put('/:id', async (req, res) => {
+  const ingredient = await updateIngredient(Number(req.params.id), req.body);
+  if (!ingredient) {
+    return res.status(404).end();
+  }
+  res.json(ingredient);
+});
+
+router.delete('/:id', async (req, res) => {
+  await deleteIngredient(Number(req.params.id));
+  res.status(204).end();
+});
+
+export default router;

--- a/backend-ts/src/services/categoryService.ts
+++ b/backend-ts/src/services/categoryService.ts
@@ -1,0 +1,30 @@
+import { getDatabase } from '../database/database';
+import { Category } from '../models/category';
+
+export async function getAllCategories(): Promise<Category[]> {
+  const db = getDatabase();
+  return db.all('SELECT id, name FROM categories');
+}
+
+export async function createCategory(category: Omit<Category, "id">): Promise<Category> {
+  const db = getDatabase();
+  const result = await db.run('INSERT INTO categories (name) VALUES (?)', [category.name]);
+  const id = (result as any).lastID as number;
+  return { id, ...category };
+}
+
+export async function findCategoryById(id: number): Promise<Category | undefined> {
+  const db = getDatabase();
+  return db.get('SELECT id, name FROM categories WHERE id = ?', [id]);
+}
+
+export async function updateCategory(id: number, update: Partial<Category>): Promise<Category | undefined> {
+  const db = getDatabase();
+  await db.run('UPDATE categories SET name = COALESCE(?, name) WHERE id = ?', [update.name, id]);
+  return findCategoryById(id);
+}
+
+export async function deleteCategory(id: number): Promise<void> {
+  const db = getDatabase();
+  await db.run('DELETE FROM categories WHERE id = ?', [id]);
+}

--- a/backend-ts/src/services/ingredientService.ts
+++ b/backend-ts/src/services/ingredientService.ts
@@ -1,0 +1,30 @@
+import { getDatabase } from '../database/database';
+import { Ingredient } from '../models/ingredient';
+
+export async function getAllIngredients(): Promise<Ingredient[]> {
+  const db = getDatabase();
+  return db.all('SELECT id, name FROM ingredients');
+}
+
+export async function createIngredient(ingredient: Omit<Ingredient, "id">): Promise<Ingredient> {
+  const db = getDatabase();
+  const result = await db.run('INSERT INTO ingredients (name) VALUES (?)', [ingredient.name]);
+  const id = (result as any).lastID as number;
+  return { id, ...ingredient };
+}
+
+export async function findIngredientById(id: number): Promise<Ingredient | undefined> {
+  const db = getDatabase();
+  return db.get('SELECT id, name FROM ingredients WHERE id = ?', [id]);
+}
+
+export async function updateIngredient(id: number, update: Partial<Ingredient>): Promise<Ingredient | undefined> {
+  const db = getDatabase();
+  await db.run('UPDATE ingredients SET name = COALESCE(?, name) WHERE id = ?', [update.name, id]);
+  return findIngredientById(id);
+}
+
+export async function deleteIngredient(id: number): Promise<void> {
+  const db = getDatabase();
+  await db.run('DELETE FROM ingredients WHERE id = ?', [id]);
+}

--- a/backend-ts/tests/category.test.ts
+++ b/backend-ts/tests/category.test.ts
@@ -1,0 +1,37 @@
+import request from 'supertest';
+import express from 'express';
+import bodyParser from 'body-parser';
+import categoryRoutes from '../src/routes/category';
+import { initDatabase, setupSchema } from '../src/database/database';
+
+const app = express();
+app.use(bodyParser.json());
+app.use('/api/category', categoryRoutes);
+
+beforeAll(async () => {
+  initDatabase(':memory:');
+  await setupSchema();
+});
+
+describe('Category routes', () => {
+  it('should create, update and delete a category', async () => {
+    const createRes = await request(app)
+      .post('/api/category')
+      .send({ name: 'Fruits' });
+    expect(createRes.status).toBe(201);
+    const id = createRes.body.id;
+
+    const listRes = await request(app).get('/api/category');
+    expect(listRes.body.length).toBe(1);
+
+    const updateRes = await request(app)
+      .put(`/api/category/${id}`)
+      .send({ name: 'Fruit' });
+    expect(updateRes.body.name).toBe('Fruit');
+
+    await request(app).delete(`/api/category/${id}`).expect(204);
+
+    const listResAfter = await request(app).get('/api/category');
+    expect(listResAfter.body.length).toBe(0);
+  });
+});

--- a/backend-ts/tests/ingredient.test.ts
+++ b/backend-ts/tests/ingredient.test.ts
@@ -1,0 +1,37 @@
+import request from 'supertest';
+import express from 'express';
+import bodyParser from 'body-parser';
+import ingredientRoutes from '../src/routes/ingredient';
+import { initDatabase, setupSchema } from '../src/database/database';
+
+const app = express();
+app.use(bodyParser.json());
+app.use('/api/ingredient', ingredientRoutes);
+
+beforeAll(async () => {
+  initDatabase(':memory:');
+  await setupSchema();
+});
+
+describe('Ingredient routes', () => {
+  it('should create, update and delete an ingredient', async () => {
+    const createRes = await request(app)
+      .post('/api/ingredient')
+      .send({ name: 'Lime' });
+    expect(createRes.status).toBe(201);
+    const id = createRes.body.id;
+
+    const listRes = await request(app).get('/api/ingredient');
+    expect(listRes.body.length).toBe(1);
+
+    const updateRes = await request(app)
+      .put(`/api/ingredient/${id}`)
+      .send({ name: 'Lemon' });
+    expect(updateRes.body.name).toBe('Lemon');
+
+    await request(app).delete(`/api/ingredient/${id}`).expect(204);
+
+    const listResAfter = await request(app).get('/api/ingredient');
+    expect(listResAfter.body.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- support category management in backend-ts
- create table and service for categories
- add `/api/category` routes
- document new endpoints and tests

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686fb61a5df88330b084cab7db08baa0